### PR TITLE
feat : 로그인, 회원가입, 회원조회 기능 추가

### DIFF
--- a/src/main/java/com/example/webtoon/config/SecurityConfig.java
+++ b/src/main/java/com/example/webtoon/config/SecurityConfig.java
@@ -1,0 +1,80 @@
+package com.example.webtoon.config;
+
+import com.example.webtoon.security.CustomUserDetailsService;
+import com.example.webtoon.security.JwtAuthenticationEntryPoint;
+import com.example.webtoon.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.BeanIds;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@EnableGlobalMethodSecurity(
+    securedEnabled = true,
+    prePostEnabled = true
+)
+public class SecurityConfig extends WebSecurityConfigurerAdapter{
+    
+
+    private final CustomUserDetailsService customUserDetailService;
+    private final JwtAuthenticationEntryPoint unauthorizedHandler;
+
+    @Bean
+    public JwtAuthenticationFilter JwtAuthenticationFilter(){
+        return new JwtAuthenticationFilter();
+    }
+
+    @Override
+    public void configure(AuthenticationManagerBuilder authenticationManagerBuilder) throws Exception{
+        authenticationManagerBuilder
+            .userDetailsService(customUserDetailService)
+            .passwordEncoder(passwordEncoder());
+    }
+
+    @Bean(BeanIds.AUTHENTICATION_MANAGER)
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .cors() //Cross Origin Resource Sharing
+                    .and()
+                .csrf()
+                    .disable() //rest api이므로 csrf 보안이 필요 없으므로 disable 처리
+                .exceptionHandling() //예외처리
+                    .authenticationEntryPoint(unauthorizedHandler) //전달 예외 잡기
+                    .and()
+                .sessionManagement()
+                    .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션은 필요없으므로 생성안함
+                    .and()
+                .authorizeRequests() //다음 리퀘스트에 대한 사용권한 체크
+                    .antMatchers("/api/signin", "/api/signup")
+                        .permitAll()
+                    .anyRequest()
+                        .authenticated(); //그 외 나머지 요청은 모두 인증된 회원만 접근가능
+
+        // Add our custom JWT security filter
+        http.addFilterBefore(JwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+    }
+}

--- a/src/main/java/com/example/webtoon/controller/AuthController.java
+++ b/src/main/java/com/example/webtoon/controller/AuthController.java
@@ -1,0 +1,26 @@
+package com.example.webtoon.controller;
+
+import com.example.webtoon.payload.LoginRequest;
+import com.example.webtoon.service.AuthService;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+
+    // 로그인
+    @PostMapping("/signin")
+    public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
+        return authService.signIn(loginRequest);
+    }
+}

--- a/src/main/java/com/example/webtoon/controller/AuthController.java
+++ b/src/main/java/com/example/webtoon/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.example.webtoon.controller;
 
 import com.example.webtoon.payload.LoginRequest;
+import com.example.webtoon.payload.SignUpRequest;
 import com.example.webtoon.service.AuthService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,5 +23,11 @@ public class AuthController {
     @PostMapping("/signin")
     public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
         return authService.signIn(loginRequest);
+    }
+
+    // 회원가입
+    @PostMapping("/signup")
+    public ResponseEntity<?> registerUser(@Valid @RequestBody SignUpRequest signUpRequest) {
+        return authService.signUp(signUpRequest);
     }
 }

--- a/src/main/java/com/example/webtoon/controller/AuthController.java
+++ b/src/main/java/com/example/webtoon/controller/AuthController.java
@@ -18,7 +18,6 @@ public class AuthController {
 
     private final AuthService authService;
 
-
     // 로그인
     @PostMapping("/signin")
     public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {

--- a/src/main/java/com/example/webtoon/controller/UserController.java
+++ b/src/main/java/com/example/webtoon/controller/UserController.java
@@ -1,0 +1,43 @@
+package com.example.webtoon.controller;
+
+
+import com.example.webtoon.entity.User;
+import com.example.webtoon.payload.UserProfile;
+import com.example.webtoon.repository.UserRepository;
+import com.example.webtoon.security.CurrentUser;
+import com.example.webtoon.security.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserRepository userRepository;
+
+
+    // 자기 자신 조회
+    @GetMapping("/user/my")
+    public UserProfile getCurrentUser(@CurrentUser UserPrincipal currentUser) {
+        return new UserProfile(currentUser.getEmail(),
+                            currentUser.getUsername(),
+                            currentUser.getNickname());
+    }
+
+    // 회원조회(관리자)
+    @GetMapping("/user/{nickname}")
+    @PreAuthorize("hasAnyRole('ADMIN')")
+    public UserProfile getUserProfile(@PathVariable(value = "nickname") String nickname) {
+        User user = userRepository.findByNickname(nickname)
+                .orElseThrow(() -> new RuntimeException());
+
+        return new UserProfile(user.getEmail(),
+                               user.getUsername(),
+                               user.getNickname());
+    }
+}

--- a/src/main/java/com/example/webtoon/entity/Role.java
+++ b/src/main/java/com/example/webtoon/entity/Role.java
@@ -1,0 +1,48 @@
+package com.example.webtoon.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import org.hibernate.annotations.NaturalId;
+
+@Entity
+@Table(name="roles")
+public class Role{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING) //열거형
+    @NaturalId
+    @Column(length = 60)
+    private RoleName name;
+
+    public Role() {
+
+    }
+
+    public Role(RoleName name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public RoleName getName() {
+        return name;
+    }
+
+    public void setName(RoleName name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/example/webtoon/entity/Role.java
+++ b/src/main/java/com/example/webtoon/entity/Role.java
@@ -17,7 +17,7 @@ public class Role{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Enumerated(EnumType.STRING) //열거형
+    @Enumerated(EnumType.STRING)
     @NaturalId
     @Column(length = 60)
     private RoleName name;

--- a/src/main/java/com/example/webtoon/entity/RoleName.java
+++ b/src/main/java/com/example/webtoon/entity/RoleName.java
@@ -1,0 +1,6 @@
+package com.example.webtoon.entity;
+
+public enum RoleName {
+    ROLE_USER,
+    ROLE_ADMIN
+}

--- a/src/main/java/com/example/webtoon/entity/User.java
+++ b/src/main/java/com/example/webtoon/entity/User.java
@@ -1,0 +1,60 @@
+package com.example.webtoon.entity;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+import javax.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Table(name = "users")
+@Entity
+@Getter
+@Setter
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Size(max = 50)
+    @Column(length = 50, unique = true)
+    private String email;
+
+    @Size(max = 20)
+    private String username;
+
+    @Size(max = 100)
+    private String password;
+
+    @Size(max = 20)
+    @Column(length = 50, unique = true)
+    private String nickname;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(name = "user_roles",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id"))
+    private Set<Role> roles = new HashSet<>();
+
+    public User() {
+
+    }
+
+    public User(String email, String username, String password, String nickname) {
+        this.email = email;
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/example/webtoon/payload/ApiResponse.java
+++ b/src/main/java/com/example/webtoon/payload/ApiResponse.java
@@ -1,0 +1,36 @@
+package com.example.webtoon.payload;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ApiResponse<T> {
+    private int statusCode;
+    private String responseMessage;
+    private T data;
+
+    public ApiResponse(final int statusCode, final String responseMessage) {
+        this.statusCode = statusCode;
+        this.responseMessage = responseMessage;
+        this.data = null;
+    }
+
+    public static<T> ApiResponse<T> res(final int statusCode, final String responseMessage) {
+        return res(statusCode, responseMessage, null);
+    }
+
+    public static<T> ApiResponse<T> res(final int statusCode, final String responseMessage, final T t) {
+        return ApiResponse.<T>builder()
+            .data(t)
+            .statusCode(statusCode)
+            .responseMessage(responseMessage)
+            .build();
+    }
+}

--- a/src/main/java/com/example/webtoon/payload/JwtAuthenticationResponse.java
+++ b/src/main/java/com/example/webtoon/payload/JwtAuthenticationResponse.java
@@ -1,0 +1,19 @@
+package com.example.webtoon.payload;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class JwtAuthenticationResponse {
+    private String accessToken;
+    private String tokenType = "Bearer";
+
+    public JwtAuthenticationResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/com/example/webtoon/payload/LoginRequest.java
+++ b/src/main/java/com/example/webtoon/payload/LoginRequest.java
@@ -1,0 +1,12 @@
+package com.example.webtoon.payload;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginRequest {
+
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/example/webtoon/payload/ResponseMessage.java
+++ b/src/main/java/com/example/webtoon/payload/ResponseMessage.java
@@ -1,0 +1,10 @@
+package com.example.webtoon.payload;
+
+public class ResponseMessage {
+    public static final String LOGIN_SUCCESS = "로그인 성공";
+    public static final String LOGIN_FAIL_NO_EMAIL_EXIST = "가입된 이메일 주소 없음";
+    public static final String LOGIN_FAIL_PASSWORD_WRONG = "비밀번호 불일치";
+    public static final String CREATED_USER = "회원 가입 성공";
+    public static final String ALREADY_EXISTED_EMAIL = "중복된 이메일 주소";
+    public static final String ALREADY_EXISTED_NICKNAME = "중복된 닉네임";
+}

--- a/src/main/java/com/example/webtoon/payload/SignUpRequest.java
+++ b/src/main/java/com/example/webtoon/payload/SignUpRequest.java
@@ -1,0 +1,14 @@
+package com.example.webtoon.payload;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignUpRequest {
+
+    private String email;
+    private String username;
+    private String password;
+    private String nickname;
+}

--- a/src/main/java/com/example/webtoon/payload/StatusCode.java
+++ b/src/main/java/com/example/webtoon/payload/StatusCode.java
@@ -1,0 +1,14 @@
+package com.example.webtoon.payload;
+
+public class StatusCode {
+    public static final int OK = 200;
+    public static final int CREATED = 201;
+    public static final int NO_CONTENT = 204;
+    public static final int BAD_REQUEST = 400;
+    public static final int UNAUTHORIZED = 401;
+    public static final int FORBIDDEN = 403;
+    public static final int NOT_FOUND = 404;
+    public static final int INTERNAL_SERVER_ERROR = 500;
+    public static final int SERVICE_UNAVAILABLE = 503;
+    public static final int DB_ERROR = 600;
+}

--- a/src/main/java/com/example/webtoon/payload/UserProfile.java
+++ b/src/main/java/com/example/webtoon/payload/UserProfile.java
@@ -1,0 +1,17 @@
+package com.example.webtoon.payload;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserProfile {
+
+    private String email;
+    private String username;
+    private String nickname;
+}

--- a/src/main/java/com/example/webtoon/repository/RoleRepository.java
+++ b/src/main/java/com/example/webtoon/repository/RoleRepository.java
@@ -1,0 +1,12 @@
+package com.example.webtoon.repository;
+
+import com.example.webtoon.entity.Role;
+import com.example.webtoon.entity.RoleName;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Optional<Role> findByName(RoleName roleName);
+}

--- a/src/main/java/com/example/webtoon/repository/UserRepository.java
+++ b/src/main/java/com/example/webtoon/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.example.webtoon.repository;
+
+import com.example.webtoon.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/example/webtoon/repository/UserRepository.java
+++ b/src/main/java/com/example/webtoon/repository/UserRepository.java
@@ -8,4 +8,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByNickname(String nickname);
+
+    Boolean existsByNickname(String nickname);
+
+    Boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/webtoon/security/CurrentUser.java
+++ b/src/main/java/com/example/webtoon/security/CurrentUser.java
@@ -1,0 +1,14 @@
+package com.example.webtoon.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE}) // 어노테이션이 적용할 위치 : 타입 선언, 매개 변수 선언 시
+@Retention(RetentionPolicy.RUNTIME) // 어노테이션의 범위 : 컴파일 이후에도 JVM에 의해서 참조 가능
+@AuthenticationPrincipal // 현재 인증 유저에 접근
+public @interface CurrentUser { // custom annotation : @interface
+
+} 

--- a/src/main/java/com/example/webtoon/security/CustomUserDetailsService.java
+++ b/src/main/java/com/example/webtoon/security/CustomUserDetailsService.java
@@ -1,0 +1,40 @@
+package com.example.webtoon.security;
+
+import com.example.webtoon.entity.User;
+import com.example.webtoon.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public UserDetails loadUserByUsername(String email)
+            throws UsernameNotFoundException {
+        // email 로 로그인
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> 
+                        new UsernameNotFoundException("User not found with username or email : " + email)
+        );
+
+        return UserPrincipal.create(user);
+    }
+
+    // JWTAuthenticationFilter 에서 사용
+    @Transactional
+    public UserDetails loadUserById(Long id) {
+        User user = userRepository.findById(id).orElseThrow(
+            () -> new UsernameNotFoundException("User not found with id : " + id)
+        );
+
+        return UserPrincipal.create(user);
+    }
+}

--- a/src/main/java/com/example/webtoon/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/webtoon/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,24 @@
+package com.example.webtoon.security;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticationEntryPoint.class);
+    @Override
+    public void commence(HttpServletRequest httpServletRequest,
+                         HttpServletResponse httpServletResponse,
+                         AuthenticationException e) throws IOException, ServletException {
+        logger.error("Responding with unauthorized error. Message - {}", e.getMessage());
+        httpServletResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
+    }
+}

--- a/src/main/java/com/example/webtoon/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/webtoon/security/JwtAuthenticationFilter.java
@@ -1,0 +1,61 @@
+package com.example.webtoon.security;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+
+//jwt가 유효한 토큰인지 인증하는 filter
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JwtTokenProvider tokenProvider;
+
+    @Autowired
+    private CustomUserDetailsService customUserDetailsService;
+
+    private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+
+    // Request로 들어오는 Jwt Token의 유효성 검증(jwtTokenProvider.validateToken)하는
+    // filter를 filterChain에 등록
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String jwt = getJwtFromRequest(request);
+
+            if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+                Long userId = tokenProvider.getUserIdFromJWT(jwt); //jwt토큰에서 회원구별 정보(id) 추출 
+
+                UserDetails userDetails = customUserDetailsService.loadUserById(userId); // 추출한 id로 detail 가져오기 
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()); // 해당 id에 대한 권한 가져오기
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                SecurityContextHolder.getContext().setAuthentication(authentication); //인증정보 spring security’s context에 set
+            }
+        } catch (Exception ex) {
+            logger.error("Could not set user authentication in security context", ex);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) { // 요청 받기
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7, bearerToken.length());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/example/webtoon/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/webtoon/security/JwtTokenProvider.java
@@ -1,0 +1,72 @@
+package com.example.webtoon.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import java.util.Date;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider { //Jwt 토큰 생성 및 유효성 검증 컴포넌트 
+
+    private static final Logger logger = LoggerFactory.getLogger(JwtTokenProvider.class);
+
+    @Value("${jwt.secret}") // yml 에 저장
+    private String jwtSecret;
+
+    @Value("${jwt.token-validity-in-seconds}") //유효기간
+    private int jwtExpirationInMs; 
+
+    //Jwt 토큰 생성
+    public String generateToken(Authentication authentication) {
+
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + jwtExpirationInMs); //만기 날짜
+
+        return Jwts.builder()
+                .setSubject(Long.toString(userPrincipal.getId())) //데이터
+                .setIssuedAt(new Date()) //토큰 발행 일자
+                .setExpiration(expiryDate) //만기 기간
+                .signWith(SignatureAlgorithm.HS512, jwtSecret) //암호화 알고리즘, secret값 세팅
+                .compact();
+    }
+
+    // Jwt 토큰에서 회원구별 정보 추출
+    public Long getUserIdFromJWT(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(jwtSecret)
+                .parseClaimsJws(token)
+                .getBody();
+
+        return Long.parseLong(claims.getSubject());
+    }
+
+    // Jwt 토큰의 유효성 확인
+    public boolean validateToken(String authToken) {
+        try {
+            Jwts.parser().setSigningKey(jwtSecret).parseClaimsJws(authToken);
+            return true;
+        } catch (SignatureException ex) {
+            logger.error("Invalid JWT signature");
+        } catch (MalformedJwtException ex) {
+            logger.error("Invalid JWT token");
+        } catch (ExpiredJwtException ex) {
+            logger.error("Expired JWT token");
+        } catch (UnsupportedJwtException ex) {
+            logger.error("Unsupported JWT token");
+        } catch (IllegalArgumentException ex) {
+            logger.error("JWT claims string is empty.");
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/example/webtoon/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/webtoon/security/JwtTokenProvider.java
@@ -15,7 +15,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 @Component
-public class JwtTokenProvider { //Jwt 토큰 생성 및 유효성 검증 컴포넌트 
+public class JwtTokenProvider { // Jwt 토큰 생성 및 유효성 검증 컴포넌트
 
     private static final Logger logger = LoggerFactory.getLogger(JwtTokenProvider.class);
 
@@ -31,13 +31,13 @@ public class JwtTokenProvider { //Jwt 토큰 생성 및 유효성 검증 컴포�
         UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
 
         Date now = new Date();
-        Date expiryDate = new Date(now.getTime() + jwtExpirationInMs); //만기 날짜
+        Date expiryDate = new Date(now.getTime() + jwtExpirationInMs); // 만기 날짜
 
         return Jwts.builder()
-                .setSubject(Long.toString(userPrincipal.getId())) //데이터
+                .setSubject(Long.toString(userPrincipal.getId())) // 데이터
                 .setIssuedAt(new Date()) //토큰 발행 일자
                 .setExpiration(expiryDate) //만기 기간
-                .signWith(SignatureAlgorithm.HS512, jwtSecret) //암호화 알고리즘, secret값 세팅
+                .signWith(SignatureAlgorithm.HS512, jwtSecret) // 암호화 알고리즘, secret 값 세팅
                 .compact();
     }
 

--- a/src/main/java/com/example/webtoon/security/UserPrincipal.java
+++ b/src/main/java/com/example/webtoon/security/UserPrincipal.java
@@ -1,0 +1,103 @@
+package com.example.webtoon.security;
+
+import com.example.webtoon.entity.User;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class UserPrincipal implements UserDetails {
+
+    private Long userId;
+
+    private String email;
+
+    private String username;
+
+    private String password;
+
+    private String nickname;
+
+    private Collection<? extends GrantedAuthority> authorities; //계정이 갖고 있는 권한 목록
+
+    public UserPrincipal(Long userId, String username,String nickname, Collection<? extends GrantedAuthority> authorities) {
+        this.userId = userId;
+        this.username = username;
+        this.nickname = nickname;
+        this.authorities = authorities;
+    }
+
+    public UserPrincipal(Long userId, String email, String username, String password, String nickname, Collection<? extends GrantedAuthority> authorities) {
+        this.userId = userId;
+        this.email = email;
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+        this.authorities = authorities;
+    }
+
+    public static UserPrincipal create(User user) {
+        List<GrantedAuthority> authorities = user.getRoles().stream().map(role ->
+                new SimpleGrantedAuthority(role.getName().name())
+        ).collect(Collectors.toList());
+
+        return new UserPrincipal(
+                user.getUserId(),
+                user.getEmail(),
+                user.getUsername(),
+                user.getPassword(),
+                user.getNickname(),
+                authorities
+        );
+    }
+
+    public Long getId() {
+        return userId;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/example/webtoon/service/AuthService.java
+++ b/src/main/java/com/example/webtoon/service/AuthService.java
@@ -1,0 +1,35 @@
+package com.example.webtoon.service;
+
+import com.example.webtoon.payload.JwtAuthenticationResponse;
+import com.example.webtoon.payload.LoginRequest;
+import com.example.webtoon.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider tokenProvider;
+
+    public ResponseEntity<?> signIn(LoginRequest loginRequest) {
+
+        Authentication authentication = authenticationManager.authenticate(
+            new UsernamePasswordAuthenticationToken(
+                loginRequest.getEmail(),
+                loginRequest.getPassword()
+            )
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        String jwt = tokenProvider.generateToken(authentication);
+        return ResponseEntity.ok(new JwtAuthenticationResponse(jwt));
+    }
+}

--- a/src/main/java/com/example/webtoon/service/AuthService.java
+++ b/src/main/java/com/example/webtoon/service/AuthService.java
@@ -1,14 +1,25 @@
 package com.example.webtoon.service;
 
+import com.example.webtoon.entity.Role;
+import com.example.webtoon.entity.RoleName;
+import com.example.webtoon.entity.User;
+import com.example.webtoon.payload.ApiResponse;
 import com.example.webtoon.payload.JwtAuthenticationResponse;
 import com.example.webtoon.payload.LoginRequest;
+import com.example.webtoon.payload.ResponseMessage;
+import com.example.webtoon.payload.SignUpRequest;
+import com.example.webtoon.payload.StatusCode;
+import com.example.webtoon.repository.RoleRepository;
+import com.example.webtoon.repository.UserRepository;
 import com.example.webtoon.security.JwtTokenProvider;
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,7 +28,11 @@ public class AuthService {
 
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider tokenProvider;
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+    private final PasswordEncoder passwordEncoder;
 
+    // 로그인
     public ResponseEntity<?> signIn(LoginRequest loginRequest) {
 
         Authentication authentication = authenticationManager.authenticate(
@@ -31,5 +46,34 @@ public class AuthService {
 
         String jwt = tokenProvider.generateToken(authentication);
         return ResponseEntity.ok(new JwtAuthenticationResponse(jwt));
+    }
+
+    // 회원가입
+    public ResponseEntity<?> signUp(SignUpRequest signUpRequest) {
+
+        if(userRepository.existsByEmail(signUpRequest.getEmail())) {
+            return ResponseEntity.ok(new ApiResponse(
+                StatusCode.BAD_REQUEST, ResponseMessage.ALREADY_EXISTED_EMAIL));
+        }
+
+        if(userRepository.existsByNickname(signUpRequest.getNickname())) {
+            return ResponseEntity.ok(new ApiResponse(
+                StatusCode.BAD_REQUEST, ResponseMessage.ALREADY_EXISTED_NICKNAME));
+        }
+
+        // Creating user's account
+        User user = new User(signUpRequest.getEmail(), signUpRequest.getUsername(),
+            signUpRequest.getPassword(), signUpRequest.getNickname());
+
+        Role userRole = roleRepository.findByName(RoleName.ROLE_USER)
+            .orElseThrow(() -> new RuntimeException());
+
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+        user.setRoles(Collections.singleton(userRole));
+
+        User result = userRepository.save(user);
+
+        return ResponseEntity.ok(new ApiResponse(
+            StatusCode.OK, ResponseMessage.CREATED_USER, result));
     }
 }

--- a/src/main/java/com/example/webtoon/service/AuthService.java
+++ b/src/main/java/com/example/webtoon/service/AuthService.java
@@ -61,7 +61,7 @@ public class AuthService {
                 StatusCode.BAD_REQUEST, ResponseMessage.ALREADY_EXISTED_NICKNAME));
         }
 
-        // Creating user's account
+        
         User user = new User(signUpRequest.getEmail(), signUpRequest.getUsername(),
             signUpRequest.getPassword(), signUpRequest.getNickname());
 


### PR DESCRIPTION
## 변경사항 
- 기능 구현을 하다가 잘 되지 않아서 여러번 구조를 바꿨습니다. 
그 과정에서 시간이 좀 걸렸고, 그래서 아직 좀 빈 부분이 있습니다.
일단 구현 한 부분만이라도 올렸습니다.

### AS-IS
1. 로그인 기능 추가
- 이메일과 비밀번호로 로그인 합니다.
- 로그인에 성공하면 JWT 토큰이 발행됩니다.
2. 회원가입 기능
- 이메일, 이름, 닉네임, 비밀번호로 회원가입 합니다.
- 이메일과 닉네임은 중복 확인 후, 중복시에는 ApiResponse를 통해서 결과를 출력합니다.
3. 자신의 정보 조회
- 자기 자신의 정보만 조회 가능합니다. (이메일, 이름, 닉네임)
- @AuthenticationPrincipal을 사용한 Custom annotation을 사용해서 로그인 한 회원 정보를 받아왔습니다.
4. 회원정보 조회(관리자)
- 관리자만 조회 가능하고 (이메일, 이름, 닉네임) , @pathvariable을 통해 닉네임으로 다른 회원의 정보를 조회 할 수 있습니다.
### TO-BE
1. 아직 exception 처리가 안된 부분이 좀 있습니다. 
- 로그인 할 경우 아이디 존재 여부, 비밀번호 일치 여부 추가할 예정입니다.
- 회원 조회시 회원이 없는 경우 등 RuntimeException으로 해 놓은 부분도 바꿀 예정입니다.
2. 아직 테스트 코드 작성을 하지 못했습니다. Postman으로 테스트 시에는 전부 작동되었습니다. 
- 아래는 테스트 예정입니다.
- [ ] 로그인 성공 / 실패
- [ ] 회원가입 성공 / 실패
- [ ] 자기 자신 정보 조회
- [ ] 회원 조회(관리자)
3. 부여한 평점 목록, 작성한 댓글 목록 등의 회원 정보 추가는 
추후 웹툰, 평점, 댓글 등 기능 구현 이후 추가할 예정입니다.

## 테스트 
- [ ] 테스트 코드
- [x] API 테스트 
- Postman으로 api테스트만 완료한 상태입니다.