### PR TITLE
Feat: 캐싱 구현, 조회수(중복방지) 구현

### DIFF
--- a/src/main/java/com/example/webtoon/config/CacheConfig.java
+++ b/src/main/java/com/example/webtoon/config/CacheConfig.java
@@ -1,0 +1,46 @@
+package com.example.webtoon.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+public class CacheConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration conf = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+            .fromConnectionFactory(redisConnectionFactory)
+            .cacheDefaults(conf)
+            .build();
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration conf = new RedisStandaloneConfiguration();
+        conf.setHostName(host);
+        conf.setPort(port);
+        return new LettuceConnectionFactory(conf);
+    }
+}

--- a/src/main/java/com/example/webtoon/config/RequestUtils.java
+++ b/src/main/java/com/example/webtoon/config/RequestUtils.java
@@ -1,0 +1,17 @@
+package com.example.webtoon.config;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class RequestUtils {
+
+    public static String getClientIp(HttpServletRequest request) {
+        String ip = null;
+        ip = request.getHeader("X-Forwarded-For");
+
+        if (ip == null) {
+            ip = request.getRemoteAddr();
+        }
+
+        return ip;
+    }
+}

--- a/src/main/java/com/example/webtoon/config/RestPage.java
+++ b/src/main/java/com/example/webtoon/config/RestPage.java
@@ -1,0 +1,24 @@
+package com.example.webtoon.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"pageable"})
+public class RestPage<T> extends PageImpl<T> {
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public RestPage(@JsonProperty("content") List<T> content,
+        @JsonProperty("number") int page,
+        @JsonProperty("size") int size,
+        @JsonProperty("totalElements") long total) {
+        super(content, PageRequest.of(page, size), total);
+    }
+
+    public RestPage(Page<T> page) {
+        super(page.getContent(), page.getPageable(), page.getTotalElements());
+    }
+}

--- a/src/main/java/com/example/webtoon/controller/AuthController.java
+++ b/src/main/java/com/example/webtoon/controller/AuthController.java
@@ -2,10 +2,10 @@ package com.example.webtoon.controller;
 
 import com.example.webtoon.dto.ApiResponse;
 import com.example.webtoon.dto.LoginRequest;
-import com.example.webtoon.type.ResponseCode;
 import com.example.webtoon.dto.SignUpRequest;
 import com.example.webtoon.dto.TokenResponse;
 import com.example.webtoon.service.AuthService;
+import com.example.webtoon.type.ResponseCode;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/example/webtoon/controller/CommentController.java
+++ b/src/main/java/com/example/webtoon/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.example.webtoon.controller;
 
+import com.example.webtoon.config.RestPage;
 import com.example.webtoon.dto.ApiResponse;
 import com.example.webtoon.dto.CommentDto;
 import com.example.webtoon.security.CurrentUser;
@@ -7,6 +8,7 @@ import com.example.webtoon.security.UserPrincipal;
 import com.example.webtoon.service.CommentService;
 import com.example.webtoon.type.ResponseCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -39,12 +41,13 @@ public class CommentController {
     }
 
     // 댓글 전체 목록 조회
+    @Cacheable(key = "#episodeId + ', page: ' + #page", value = "commentList")
     @GetMapping("/comment/{episodeId}")
     public ApiResponse<Page<CommentDto>> getCommentList(@PathVariable Long episodeId,
                                                         @RequestParam(defaultValue = "0") Integer page) {
         Page<CommentDto> commentList = commentService.getCommentList(episodeId, page);
         return new ApiResponse<>(
-            HttpStatus.OK, ResponseCode.GET_COMMENT_LIST_SUCCESS, commentList);
+            HttpStatus.OK, ResponseCode.GET_COMMENT_LIST_SUCCESS, new RestPage<>(commentList));
     }
 
     // 댓글 수정

--- a/src/main/java/com/example/webtoon/controller/UserController.java
+++ b/src/main/java/com/example/webtoon/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.example.webtoon.controller;
 
 
+import com.example.webtoon.config.RestPage;
 import com.example.webtoon.dto.ApiResponse;
 import com.example.webtoon.dto.CommentDto;
 import com.example.webtoon.dto.EpisodeIdListDto;
@@ -11,6 +12,7 @@ import com.example.webtoon.security.UserPrincipal;
 import com.example.webtoon.service.UserService;
 import com.example.webtoon.type.ResponseCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -46,31 +48,34 @@ public class UserController {
     }
 
     // 유저가 평점 부여한 에피소드 목록 조회
+    @Cacheable(key = "#currentUser.id + ', givAvg' + ', page: ' + #page", value = "episodeAvgListbyUser")
     @GetMapping("/user/webtoon/rated")
     public ApiResponse<Page<EpisodeIdListDto>> getEpisodeRatedByUser(@CurrentUser UserPrincipal currentUser,
                                                                      @RequestParam(defaultValue = "0") Integer page) {
         Page<EpisodeIdListDto> episodeList =
             userService.getEpisodeRatedByUser(currentUser.getId(), page);
         return new ApiResponse<>(
-            HttpStatus.OK, ResponseCode.GET_RATED_EPISODE_LIST_SUCCESS, episodeList);
+            HttpStatus.OK, ResponseCode.GET_RATED_EPISODE_LIST_SUCCESS, new RestPage<>(episodeList));
     }
 
     // 유저가 작성한 댓글 목록 조회
+    @Cacheable(key = "#currentUser.id + ', comment' + ', page: ' + #page", value = "commentListbyUser")
     @GetMapping("/user/comments")
     public ApiResponse<Page<CommentDto>> getCommentsByUser(@CurrentUser UserPrincipal currentUser,
                                                            @RequestParam(defaultValue = "0") Integer page) {
         Page<CommentDto> commentList = userService.getCommentsByUser(currentUser.getId(), page);
         return new ApiResponse<>(
-            HttpStatus.OK, ResponseCode.GET_COMMENT_LIST_SUCCESS, commentList);
+            HttpStatus.OK, ResponseCode.GET_COMMENT_LIST_SUCCESS, new RestPage<>(commentList));
     }
 
     // 선호 작품 목록 조회
+    @Cacheable(key = "#currentUser.id + ', Fav' + ', page: ' + #page", value = "FavList")
     @GetMapping("/user/fav-webtoon")
     public ApiResponse<Page<WebtoonIdListDto>> getFavWebtoonList(@CurrentUser UserPrincipal currentUser,
                                                                  @RequestParam(defaultValue = "0") Integer page) {
         Page<WebtoonIdListDto> favWebtoonList =
             userService.getFavWebtoonList(currentUser.getId(), page);
         return new ApiResponse<>(
-            HttpStatus.OK, ResponseCode.GET_FAV_WEBTOON_LIST_SUCCESS, favWebtoonList);
+            HttpStatus.OK, ResponseCode.GET_FAV_WEBTOON_LIST_SUCCESS, new RestPage<>(favWebtoonList));
     }
 }

--- a/src/main/java/com/example/webtoon/controller/WebtoonController.java
+++ b/src/main/java/com/example/webtoon/controller/WebtoonController.java
@@ -1,5 +1,6 @@
 package com.example.webtoon.controller;
 
+import com.example.webtoon.config.RestPage;
 import com.example.webtoon.dto.ApiResponse;
 import com.example.webtoon.dto.EpisodeDto;
 import com.example.webtoon.dto.WebtoonDto;
@@ -102,26 +103,27 @@ public class WebtoonController {
     }
 
     // 웹툰 에피소드 조회
-    @Cacheable(key = "#webtoonId", value = "webtoonId")
+    @Cacheable(key = "#webtoonId + ', page: ' + #page", value = "episodeList")
     @GetMapping("/webtoon/episodes/{webtoonId}")
     public ApiResponse<Page<EpisodeDto>> getWebtoonEpisodes(@PathVariable Long webtoonId,
                                                             @RequestParam(defaultValue = "0") Integer page) {
         Page<EpisodeDto> episodeDtoList = webtoonService.getWebtoonEpisodes(webtoonId, page);
         return new ApiResponse<>(
-            HttpStatus.OK, ResponseCode.GET_EPISODES_SUCCESS, episodeDtoList);
+            HttpStatus.OK, ResponseCode.GET_EPISODES_SUCCESS, new RestPage<>(episodeDtoList));
     }
 
     // 웹툰 요일별 조회 (업데이트순, 평점순, 조회수순)
+    @Cacheable(key = "#day + ', sort: ' + #sortType.toString() + ', page: ' + #page", value = "webtoonList")
     @GetMapping("/webtoon")
     public ApiResponse<Page<WebtoonDto>> getWebtoonByDay(
-        @RequestParam(defaultValue = "월요일") String day,
+        @RequestParam(defaultValue = "MON") String day,
         @RequestParam(defaultValue = "new") SortType sortType,
         @RequestParam(defaultValue = "0") Integer page) {
 
         Page<WebtoonDto> webtoonList = webtoonService.getWebtoonByDay(day, sortType, page);
 
         return new ApiResponse<>(
-            HttpStatus.OK, ResponseCode.GET_WEBTOON_BY_DAY_SUCCESS, webtoonList);
+            HttpStatus.OK, ResponseCode.GET_WEBTOON_BY_DAY_SUCCESS, new RestPage<>(webtoonList));
     }
 
     // 검색한 웹툰 조회

--- a/src/main/java/com/example/webtoon/dto/ApiResponse.java
+++ b/src/main/java/com/example/webtoon/dto/ApiResponse.java
@@ -1,11 +1,21 @@
 package com.example.webtoon.dto;
 
 import com.example.webtoon.type.ResponseCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonCreator.Mode;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.lang.Nullable;
 
@@ -13,7 +23,6 @@ import org.springframework.lang.Nullable;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class ApiResponse<T> {
 
     private int status;

--- a/src/main/java/com/example/webtoon/dto/ApiResponse.java
+++ b/src/main/java/com/example/webtoon/dto/ApiResponse.java
@@ -1,21 +1,10 @@
 package com.example.webtoon.dto;
 
 import com.example.webtoon.type.ResponseCode;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonCreator.Mode;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.lang.Nullable;
 

--- a/src/main/java/com/example/webtoon/entity/DateEntity.java
+++ b/src/main/java/com/example/webtoon/entity/DateEntity.java
@@ -1,5 +1,9 @@
 package com.example.webtoon.entity;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import java.time.LocalDateTime;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
@@ -16,8 +20,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class DateEntity {
 
     @CreatedDate
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateDeserializer.class)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateDeserializer.class)
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/example/webtoon/entity/View.java
+++ b/src/main/java/com/example/webtoon/entity/View.java
@@ -1,0 +1,25 @@
+package com.example.webtoon.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+public class View {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long viewId;
+
+    private String userIP;
+
+    @ManyToOne
+    @JoinColumn(name = "webtoon_id")
+    private Webtoon webtoon;
+}

--- a/src/main/java/com/example/webtoon/repository/ViewRepository.java
+++ b/src/main/java/com/example/webtoon/repository/ViewRepository.java
@@ -1,0 +1,11 @@
+package com.example.webtoon.repository;
+
+import com.example.webtoon.entity.View;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ViewRepository extends JpaRepository<View, Long> {
+
+    boolean existsByUserIPAndWebtoon_WebtoonId(String ip, Long webtoonId);
+}

--- a/src/main/java/com/example/webtoon/service/CommentService.java
+++ b/src/main/java/com/example/webtoon/service/CommentService.java
@@ -10,6 +10,8 @@ import com.example.webtoon.repository.EpisodeRepository;
 import com.example.webtoon.repository.UserRepository;
 import com.example.webtoon.type.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -27,6 +29,8 @@ public class CommentService {
     private final CommentRepository commentRepository;
 
     // 댓글 신규 작성
+    @Caching(evict = {@CacheEvict(value = "commentList", allEntries = true),
+                      @CacheEvict(value = "commentListbyUser", allEntries = true)})
     public CommentDto createComment(Long episodeId, Long userId, String userComment) {
 
         Episode episode = episodeRepository.findById(episodeId).orElseThrow(
@@ -44,6 +48,8 @@ public class CommentService {
     }
 
     // 댓글 수정
+    @Caching(evict = {@CacheEvict(value = "commentList", allEntries = true),
+                      @CacheEvict(value = "commentListbyUser", allEntries = true)})
     public CommentDto updateComment(Long commentId, Long userId, String userComment) {
         Comment comment = commentRepository.findByCommentIdAndUser_UserId(commentId, userId)
             .orElseThrow(() -> new CustomException(
@@ -56,6 +62,8 @@ public class CommentService {
     }
 
     // 댓글 삭제
+    @Caching(evict = {@CacheEvict(value = "commentList", allEntries = true),
+                      @CacheEvict(value = "commentListbyUser", allEntries = true)})
     public void deleteComment(Long commentId, Long userId) {
 
         // 댓글이 있는지 확인
@@ -72,6 +80,8 @@ public class CommentService {
     }
 
     // 댓글 삭제 (관리자)
+    @Caching(evict = {@CacheEvict(value = "commentList", allEntries = true),
+                      @CacheEvict(value = "commentListbyUser", allEntries = true)})
     public void deleteCommentByAdmin(Long commentId) {
         if (!commentRepository.existsById(commentId)) {
             throw new CustomException(HttpStatus.NOT_FOUND, ErrorCode.COMMENT_NOT_FOUND);

--- a/src/main/java/com/example/webtoon/service/FavService.java
+++ b/src/main/java/com/example/webtoon/service/FavService.java
@@ -10,6 +10,7 @@ import com.example.webtoon.repository.UserRepository;
 import com.example.webtoon.repository.WebtoonRepository;
 import com.example.webtoon.type.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
@@ -22,6 +23,7 @@ public class FavService {
     private final FavRepository favRepository;
 
     // 선호 작품 등록
+    @CacheEvict(value = "FavList", allEntries = true)
     public WebtoonIdListDto addFavWebtoon(Long webtoonId, Long userId) {
         Webtoon webtoon = webtoonRepository.findById(webtoonId).orElseThrow(() -> new CustomException(
             HttpStatus.NOT_FOUND, ErrorCode.WEBTOON_NOT_FOUND));
@@ -41,6 +43,7 @@ public class FavService {
     }
 
     // 선호 작품 삭제
+    @CacheEvict(value = "FavList", allEntries = true)
     public void deleteFavWebtoon(Long webtoonId, Long userId) {
         if (!favRepository.existsByWebtoon_WebtoonIdAndUser_UserId(webtoonId, userId)) {
             throw new CustomException(HttpStatus.NOT_FOUND, ErrorCode.FAV_WEBTOON_NOT_FOUND);

--- a/src/main/java/com/example/webtoon/service/RateService.java
+++ b/src/main/java/com/example/webtoon/service/RateService.java
@@ -12,6 +12,7 @@ import com.example.webtoon.repository.UserRepository;
 import com.example.webtoon.repository.WebtoonRepository;
 import com.example.webtoon.type.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,6 +27,7 @@ public class RateService {
     private final RateRepository rateRepository;
 
     // 평점 등록
+    @CacheEvict(value = "episodeAvgListbyUser", allEntries = true)
     public RateDto addRate(Long episodeId, Long userId, Integer userRate) {
 
         if (rateRepository.existsByEpisode_EpisodeIdAndUser_UserId(episodeId, userId)) {
@@ -49,6 +51,7 @@ public class RateService {
     }
 
     // 평점 수정
+    @CacheEvict(value = "episodeAvgListbyUser", allEntries = true)
     public RateDto updateRate(Long episodeId, Long userId, Integer userRate) {
         Rate rate = rateRepository.findByEpisode_EpisodeIdAndUser_UserId(episodeId, userId)
             .orElseThrow(() ->new CustomException(
@@ -61,6 +64,7 @@ public class RateService {
     }
 
     // 평점 삭제
+    @CacheEvict(value = "episodeAvgListbyUser", allEntries = true)
     public void deleteRate(Long episodeId, Long userId) {
         if (!rateRepository.existsByEpisode_EpisodeIdAndUser_UserId(episodeId, userId)) {
             throw new CustomException(HttpStatus.NOT_FOUND, ErrorCode.RATE_NOT_FOUND);

--- a/src/main/java/com/example/webtoon/service/ViewService.java
+++ b/src/main/java/com/example/webtoon/service/ViewService.java
@@ -1,0 +1,37 @@
+package com.example.webtoon.service;
+
+import com.example.webtoon.config.RequestUtils;
+import com.example.webtoon.entity.View;
+import com.example.webtoon.entity.Webtoon;
+import com.example.webtoon.exception.CustomException;
+import com.example.webtoon.repository.ViewRepository;
+import com.example.webtoon.repository.WebtoonRepository;
+import com.example.webtoon.type.ErrorCode;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ViewService {
+
+    private final WebtoonRepository webtoonRepository;
+    private final ViewRepository viewRepository;
+
+    public void checkViewCount(Long webtoonId, HttpServletRequest request) {
+        Webtoon webtoon = webtoonRepository.findById(webtoonId).orElseThrow(
+            () -> new CustomException(HttpStatus.NOT_FOUND, ErrorCode.WEBTOON_NOT_FOUND));
+
+        String ip = RequestUtils.getClientIp(request);
+        View view = new View();
+
+        if (!viewRepository.existsByUserIPAndWebtoon_WebtoonId(ip, webtoonId)) {
+            view.setUserIP(ip);
+            view.setWebtoon(webtoon);
+            viewRepository.save(view);
+            webtoon.setViewCount(webtoon.getViewCount() + 1);
+            webtoonRepository.save(webtoon);
+        }
+    }
+}

--- a/src/main/java/com/example/webtoon/service/ViewService.java
+++ b/src/main/java/com/example/webtoon/service/ViewService.java
@@ -11,6 +11,7 @@ import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -19,14 +20,15 @@ public class ViewService {
     private final WebtoonRepository webtoonRepository;
     private final ViewRepository viewRepository;
 
+    @Transactional
     public void checkViewCount(Long webtoonId, HttpServletRequest request) {
         Webtoon webtoon = webtoonRepository.findById(webtoonId).orElseThrow(
             () -> new CustomException(HttpStatus.NOT_FOUND, ErrorCode.WEBTOON_NOT_FOUND));
 
         String ip = RequestUtils.getClientIp(request);
-        View view = new View();
 
         if (!viewRepository.existsByUserIPAndWebtoon_WebtoonId(ip, webtoonId)) {
+            View view = new View();
             view.setUserIP(ip);
             view.setWebtoon(webtoon);
             viewRepository.save(view);

--- a/src/main/java/com/example/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/example/webtoon/service/WebtoonService.java
@@ -157,7 +157,6 @@ public class WebtoonService {
     // 웹툰 에피소드 전체 목록 조회
     @Cacheable(key = "#webtoonId + ', page: ' + #page", value = "episodeList")
     public Page<EpisodeDto> getWebtoonEpisodes(Long webtoonId, Integer page) {
-        System.out.println("실행 확인 =====================");
         Pageable pageable = PageRequest.of(page, SIZE);
         Page<Episode> episodeList = episodeRepository.findByWebtoon_WebtoonId(webtoonId, pageable);
 

--- a/src/main/java/com/example/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/example/webtoon/service/WebtoonService.java
@@ -14,6 +14,7 @@ import com.example.webtoon.type.ErrorCode;
 import com.example.webtoon.type.SortType;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -34,6 +35,7 @@ public class WebtoonService {
     private final FileService fileService;
 
     // 웹툰 신규 등록
+    @CacheEvict(value = "webtoonList", allEntries = true)
     public WebtoonDto addWebtoon(String title, String artist,
                                  String day, String genre,
                                  MultipartFile file) throws IOException {
@@ -56,6 +58,7 @@ public class WebtoonService {
     }
 
     // 웹툰 수정
+    @CacheEvict(value = "webtoonList", allEntries = true)
     public WebtoonDto updateWebtoon(Long webtoonId,
                                     String title, String artist,
                                     String day, String genre,
@@ -77,6 +80,7 @@ public class WebtoonService {
     }
 
     // 웹툰 삭제
+    @CacheEvict(value = "webtoonList", allEntries = true)
     public void deleteWebtoon(Long webtoonId) {
         if (!webtoonRepository.existsById(webtoonId)) {
             throw new CustomException(HttpStatus.NOT_FOUND, ErrorCode.WEBTOON_NOT_FOUND);
@@ -85,6 +89,7 @@ public class WebtoonService {
     }
 
     // 에피소드 신규 등록
+    @CacheEvict(value = "episodeList", allEntries = true)
     public EpisodeDto addEpisode(Long webtoonId,
                                  String title,
                                  MultipartFile epFile,
@@ -107,6 +112,7 @@ public class WebtoonService {
     }
 
     // 에피소드 수정
+    @CacheEvict(value = "episodeList", allEntries = true)
     public EpisodeDto updateEpisode(Long episodeId,
                                     String title,
                                     MultipartFile epFile,
@@ -124,6 +130,7 @@ public class WebtoonService {
     }
 
     // 에피소드 삭제
+    @CacheEvict(value = "episodeList", allEntries = true)
     public void deleteEpisode(Long episodeId) {
         if (!episodeRepository.existsById(episodeId)) {
             throw new CustomException(HttpStatus.NOT_FOUND, ErrorCode.EPISODE_NOT_FOUND);

--- a/src/main/java/com/example/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/example/webtoon/service/WebtoonService.java
@@ -1,5 +1,6 @@
 package com.example.webtoon.service;
 
+import com.example.webtoon.config.RestPage;
 import com.example.webtoon.dto.EpisodeDto;
 import com.example.webtoon.dto.WebtoonDocument;
 import com.example.webtoon.dto.WebtoonDto;
@@ -15,6 +16,7 @@ import com.example.webtoon.type.SortType;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -153,14 +155,13 @@ public class WebtoonService {
     }
 
     // 웹툰 에피소드 전체 목록 조회
+    @Cacheable(key = "#webtoonId + ', page: ' + #page", value = "episodeList")
     public Page<EpisodeDto> getWebtoonEpisodes(Long webtoonId, Integer page) {
+        System.out.println("실행 확인 =====================");
         Pageable pageable = PageRequest.of(page, SIZE);
         Page<Episode> episodeList = episodeRepository.findByWebtoon_WebtoonId(webtoonId, pageable);
-        Webtoon webtoon = webtoonRepository.findById(webtoonId).orElseThrow(
-            () -> new CustomException(HttpStatus.NOT_FOUND, ErrorCode.WEBTOON_NOT_FOUND));
-        webtoon.setViewCount(webtoon.getViewCount() + 1);
-        webtoonRepository.save(webtoon);
-        return episodeList.map(EpisodeDto::from);
+
+        return new RestPage<>(episodeList.map(EpisodeDto::from));
     }
 
     // 검색한 웹툰 조회


### PR DESCRIPTION
## 변경사항 

### AS-IS
1. 캐싱
- redis를 사용해서 캐싱을 했습니다.
- 요일별 웹툰 정렬(업데이트 / 조회수 / 평점)을 조회하는 경우, look aside 캐싱 전략을 사용했습니다.
- 에피소드 목록을 조회하는 경우에도 look aside 캐싱 전략을 사용했습니다.
2. 조회수 기능
- IP와 웹툰ID로 확인해서 값이 있는 경우에는 조회수를 count하지 않습니다.
- 값이 없는 경우에는 유저 IP와 웹툰ID를 테이블에 저장합니다.


### TO-BE
1. 테스트 코드 완성

### 궁금한 사항

1. 웹툰 정렬의 경우와 에피소드 목록 조회의 경우에만 캐싱을 주었습니다. 나머지 캐싱을 고려할 부분은 **댓글**과 **유저가 읽고 쓰는 부분**(댓글 작성, 평점 부여, 선호작품 부여) 인데, 이 부분에 캐싱을 해주어야 하는지 잘 모르겠습니다. 이 부분들은 조회할 데이터가 많아서 캐싱을 하면 좋겠지만, 수정이 워낙 자주 일어나는 부분이라서 캐싱을 하는 것이 오히려 성능 저하를 일으키는 것이 아닌가 하는 생각이 듭니다. 이런 경우에는 **어떤 캐싱 전략을 사용하면 좋은지, 아니면 사용하지 않는 편이 좋은지** 궁금합니다.

## 테스트 
- [ ] 테스트 코드
- [x] API 테스트 
- Postman으로 api테스트만 완료한 상태입니다.